### PR TITLE
Use "%" for user wildcard search instead of "*"

### DIFF
--- a/openstax_accounts/example.py
+++ b/openstax_accounts/example.py
@@ -74,7 +74,7 @@ def profile(request):
 @authenticated_only
 def user_search(request):
     util = request.registry.getUtility(IOpenstaxAccounts)
-    users = util.search('*')
+    users = util.search('%')
     if request.matchdict.get('format') == '.json':
         return Response(json.dumps(users), content_type='application/json')
     return Response(menu(request) + '<p>User Search</p>{}'.format(users))

--- a/openstax_accounts/stub.py
+++ b/openstax_accounts/stub.py
@@ -175,6 +175,7 @@ class OpenstaxAccounts(object):
         self.users = users
 
     def search(self, query):
+        query = query.replace('%', '*')
         results = {
                 'application_users': [],
                 'order_by': 'username ASC',


### PR DESCRIPTION
Recent update of the accounts code exposed this incorrect use of user
wildcard search

https://github.com/openstax/accounts/commit/70aaab5f0247642d9aadb6bb96c90dd05613bcfb
