### PR TITLE
Allow html body to be passed in for send_message

### DIFF
--- a/openstax_accounts/openstax_accounts.py
+++ b/openstax_accounts/openstax_accounts.py
@@ -116,7 +116,7 @@ class OpenstaxAccounts(object):
         return self.request('/api/users.json?{}'.format(
             urlencode({'q': query})))
 
-    def send_message(self, username, subject, body):
+    def send_message(self, username, subject, text_body, html_body=None):
         users = self.global_search('username:{}'.format(username))
         userid = None
         for user in users['users']:
@@ -125,13 +125,16 @@ class OpenstaxAccounts(object):
         if userid is None:
             raise UserNotFoundException('User "{}" not found'.format(username))
 
+        if html_body is None:
+            html_body = '<html><body>{}</body></html>'.format(
+                cgi.escape(text_body).replace('\n', '\n<br/>'))
+
         msg_data = {
             'user_id': int(userid),
             'to[user_ids][]': [int(userid)],
             'subject': subject,
-            'body[text]': body,
-            'body[html]': '<html><body>{}</body></html>'.format(
-                cgi.escape(body)),
+            'body[text]': text_body,
+            'body[html]': html_body,
             }
 
         send_msg_util = get_current_registry().getUtility(IMessageSender)

--- a/openstax_accounts/tests.py
+++ b/openstax_accounts/tests.py
@@ -201,18 +201,36 @@ class FunctionalTests(unittest.TestCase):
         self.follow_link('Send Message')
         self.fill_in('Username:', 'earl')
         self.fill_in('Subject:', 'Test')
-        self.fill_in('Body:', 'Message!')
+        self.fill_in('Body:', 'Dear Earl,\n\nMessage!')
         self.driver.find_elements_by_xpath('//input')[-1].click()
         time.sleep(5)
         self.assertTrue('Message sent' in self.page_text())
         # check messages.txt
         with open('messages.txt', 'r') as f:
             messages = f.read()
-        self.assertTrue('''Subject: [subject prefix] Test
+        headers = '''Subject: [subject prefix] Test
 From: openstax-accounts@localhost
 To: earl <earl@example.com>
+'''
+        text_body = '''
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
 
-Message!''' in messages)
+Dear Earl,\r
+\r
+Message!'''
+        html_body = '''
+Content-Type: text/html; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+<html><body>Dear Earl,\r
+<br/>\r
+<br/>Message!</body></html>'''
+        self.assertIn(headers, messages)
+        self.assertIn(text_body, messages)
+        self.assertIn(html_body, messages)
         # logout
         self.follow_link('Log out')
         self.assertTrue('You are currently not logged in' in self.page_text())


### PR DESCRIPTION
If html body is not passed in, use the text body but add `<br>`s for all
the newlines.

Close Connexions/cnx-authoring#128
