### PR TITLE
Stub implementation updates

### DIFF
--- a/openstax_accounts/stub.py
+++ b/openstax_accounts/stub.py
@@ -172,19 +172,10 @@ class OpenstaxAccounts(object):
                 }
         for username in self.users:
             profile = self.users[username]['profile']
-            values = [username]
-            for key, value in profile.items():
-                if key == 'contact_infos':
-                    values.append(profile['contact_infos'][0]['value'])
-                else:
-                    values.append(value)
-
-            for value in values:
-                if fnmatch.fnmatch(username, query):
-                    results['items'].append({
-                        'username': username,
-                        'id': profile['id'],
-                        })
+            for value in profile.values():
+                if fnmatch.fnmatch(username, query) \
+                   or username in query:
+                    results['items'].append(profile)
                     break
 
         # sort results
@@ -194,6 +185,8 @@ class OpenstaxAccounts(object):
         results['total_count'] = len(results['items'])
 
         return results
+
+    global_search = search
 
     def send_message(self, username, subject, text_body, html_body=None):
         email = None

--- a/openstax_accounts/stub.py
+++ b/openstax_accounts/stub.py
@@ -27,12 +27,8 @@ DEFAULT_PROFILE = {
     'id': 1, # to be generated
     'first_name': 'Test',
     'last_name': 'User',
-    'contact_infos': [{
-        'type': 'EmailAddress',
-        'verified': True,
-        'id': 1, # to b generated
-        'value': '', # to be generated
-        }],
+    'full_name': 'Test User',
+    'title': None,
     }
 
 
@@ -46,21 +42,12 @@ def get_users_from_settings(setting):
             username, password = user.split(',', 1)
             profile = copy.deepcopy(DEFAULT_PROFILE)
 
-        if profile.get('contact_infos') is None:
-            profile['contact_infos'] = [DEFAULT_PROFILE['contact_infos'][0] \
-                                       .copy()]
-        if not profile['contact_infos'][0]['value']:
-            profile['contact_infos'][0].update({
-                'id': i + 1,
-                'value': '{}@example.com'.format(username)
-                })
-
         profile['id'] = i + 1
         profile['username'] = username
         users[username] = {
             'profile': profile,
             'password': password,
-                }
+            }
     return users
 
 

--- a/test_stub.ini
+++ b/test_stub.ini
@@ -6,7 +6,7 @@ openstax_accounts.stub = true
 # format: <username>,<password>,<optional json profile>
 openstax_accounts.stub.users =
     aaron,password,{"first_name": "Aaron", "last_name": "Andersen"}
-    babara,password
+    babara,password,{}
     caitlin,password
     dale,password
     earl,password


### PR DESCRIPTION
This updates the stub implementation to use the same API and responses you would see from an actual interaction with accounts.

(within the context of the stub implementation only)
* Removes the emails from the profiles
* Adds the ``global_search`` method
* Updates the ``send_message`` method to write the same format used by accounts.
