### PR TITLE
Refactor browser test utils and stub tests out of functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - python setup.py install
 env: DRIVER='Firefox'
 script:
-  - TESTING_INI=test_stub.ini xvfb-run python setup.py test -s openstax_accounts.tests.FunctionalTests.test_stub
+  - TESTING_INI=test_stub.ini xvfb-run python setup.py test -s openstax_accounts.tests.StubTests
   - TESTING_INI=test_local.ini xvfb-run python setup.py test -s openstax_accounts.tests.FunctionalTests.test_local
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,40 @@ TESTS
 
 1. Copy testing.ini.example to testing.ini and change the values
 
-2. Download chrome driver (and chrome if you don't have it):
-   ``wget 'http://chromedriver.storage.googleapis.com/2.9/chromedriver_linux64.zip'``
+2. Download chrome driver::
 
-3. Unzip chrome driver: ``unzip chromedriver_linux64.zip``
+     wget 'http://chromedriver.storage.googleapis.com/2.14/chromedriver_linux64.zip
 
-4. Add chrome driver to $PATH: ``export PATH=$PATH:.``
+   If you don't have chrome::
 
-5. Make sure the $DISPLAY is set, for example: ``export DISPLAY=:0`` or install ``xvfb``
+     sudo apt-get install chromium-browser
 
-6. ``./bin/python setup.py test`` or ``xvfb-run ./bin/python setup.py test``
+3. Unzip chrome driver::
+
+     unzip chromedriver_linux64.zip
+
+4. Add chrome driver to ``$PATH``::
+
+     export PATH=$PATH:.
+
+5. Make sure the ``$DISPLAY`` is set, for example::
+
+     export DISPLAY=localhost:10.0
+
+   or install ``xvfb``
+
+6. Run browser tests with openstax/accounts::
+
+     ./bin/python setup.py test -s openstax_accounts.tests.FunctionalTests
+
+   or::
+
+     xvfb-run ./bin/python setup.py test -s openstax_accounts.tests.FunctionalTests
+
+7. Run stub tests without openstax/accounts::
+
+     TESTING_INI=test_stub.ini ./bin/python setup.py test -s openstax_accounts.tests.StubTests
+
+   or::
+
+     TESTING_INI=test_stub.ini xvfb-run ./bin/python setup.py test -s openstax_accounts.tests.StubTests


### PR DESCRIPTION
The stub tests are now in `openstax_accounts.tests.StubTests`.  The
browser test util functions are in its own class `BrowserTestCase`.  The
rest of the functional tests are still in
`openstax_accounts.tests.FunctionalTests`.

Just moved code around and fix some pep8 whitespace issues.