### PR TITLE
Bundle of changes and the addition of groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,10 @@ before_install:
   # Install firefox
   - sudo apt-get install --yes firefox
 
-  # Disable SSL certificate verification added in python 2.7.9
-  # See https://bugs.python.org/issue22417
-  - sed -i '/def main/ i \import ssl\nif hasattr(ssl, "_create_unverified_context"):\n    ssl._create_default_https_context = ssl._create_unverified_context\n' openstax_accounts/__init__.py
-
 install:
   - python setup.py install
 env: DRIVER='Firefox'
 script:
-  - TESTING_INI=test_stub.ini xvfb-run python setup.py test -s openstax_accounts.tests.StubTests
-  - TESTING_INI=test_local.ini xvfb-run python setup.py test -s openstax_accounts.tests.FunctionalTests.test_local
+  - STUB_INI=test_stub.ini LOCAL_INI=test_local.ini xvfb-run python setup.py test
 notifications:
   email: false

--- a/development.ini.example
+++ b/development.ini.example
@@ -12,7 +12,12 @@ openstax_accounts.stub.users =
     dale,password
     earl,password
     fabian,password
-
+openstax_accounts.groups.grp_sol =
+    aaron
+    babara
+openstax_accounts.groups.grp_luna =
+    babara
+    dale
 openstax_accounts.login_path = /login
 openstax_accounts.callback_path = /callback
 openstax_accounts.logout_path = /logout

--- a/openstax_accounts/__init__.py
+++ b/openstax_accounts/__init__.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2015, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
 from pyramid.settings import asbool
 
 from .utils import local_settings
@@ -29,6 +35,7 @@ def includeme(config):
     settings = config.registry.settings
     settings = local_settings(settings)
 
+    declare_oauth_routes(config)
     # Disable SSL certificate verification added in python 2.7.9
     # See https://bugs.python.org/issue22417
     if asbool(settings.get('disable_verify_ssl')):
@@ -43,3 +50,4 @@ def includeme(config):
         # use the openstax accounts authentication policy
         config.include('openstax_accounts.openstax_accounts')
         config.include('openstax_accounts.authentication_policy')
+    config.scan('openstax_accounts.views')

--- a/openstax_accounts/__init__.py
+++ b/openstax_accounts/__init__.py
@@ -1,14 +1,45 @@
 # -*- coding: utf-8 -*-
-
 from pyramid.settings import asbool
 
-def main(config):
-    settings = config.registry.settings
+from .utils import local_settings
 
-    if asbool(settings.get('openstax_accounts.stub')):
-        # use the stub authentication policy
-        config.include('openstax_accounts.stub.main')
+
+# BBB (11-Mar-2015) Deprecated, use 'includeme' by invoking
+#     ``config.include('openstax_accounts')``.
+def main(config):
+    includeme(config)
+
+
+def declare_oauth_routes(config):
+    """Declaration of routing for oauth"""
+    settings = config.registry.settings
+    settings = local_settings(settings)
+    login_path = settings['login_path']
+    callback_path = settings['callback_path']
+    logout_path = settings['logout_path']
+
+    add_route = config.add_route
+    add_route('login', login_path, request_method='GET')
+    add_route('callback', callback_path, request_method='GET')
+    add_route('logout', logout_path, request_method='GET')
+
+
+def includeme(config):
+    """Includes this package into a pyramid application."""
+    settings = config.registry.settings
+    settings = local_settings(settings)
+
+    # Disable SSL certificate verification added in python 2.7.9
+    # See https://bugs.python.org/issue22417
+    if asbool(settings.get('disable_verify_ssl')):
+        import ssl
+        if hasattr(ssl, "_create_unverified_context"):
+            ssl._create_default_https_context = ssl._create_unverified_context
+
+    if asbool(settings.get('stub')):
+        # Use the stub authentication policy
+        config.include('openstax_accounts.stub')
     else:
         # use the openstax accounts authentication policy
-        config.include('openstax_accounts.openstax_accounts.main')
-        config.include('openstax_accounts.authentication_policy.main')
+        config.include('openstax_accounts.openstax_accounts')
+        config.include('openstax_accounts.authentication_policy')

--- a/openstax_accounts/authentication_policy.py
+++ b/openstax_accounts/authentication_policy.py
@@ -15,7 +15,7 @@ from pyramid.security import Everyone, Authenticated
 from zope.interface import implementer
 
 from .interfaces import *
-
+from .utils import local_settings
 
 def get_user_from_session(request):
     """Create a helper function for getting the user profile from request.user
@@ -86,14 +86,21 @@ class OpenstaxAccountsAuthenticationPolicy(object):
             raise HTTPFound(location='?'.join([logout_url, params]))
 
 
+# BBB (11-Mar-2015) Deprecated, use 'includeme' by invoking
+#     ``config.include('openstax_accounts')``.
 def main(config):
+    includeme(config)
+
+
+def includeme(config):
     config.add_request_method(get_user_from_session, 'user', reify=True)
     config.add_request_method(get_accounts_client, 'accounts_client',
                               reify=True)
     settings = config.registry.settings
+    settings = local_settings(settings)
     config.registry.registerUtility(OpenstaxAccountsAuthenticationPolicy(
-        application_url=settings['openstax_accounts.application_url'],
-        login_path=settings['openstax_accounts.login_path'],
-        callback_path=settings['openstax_accounts.callback_path'],
-        logout_path=settings['openstax_accounts.logout_path'],
+        application_url=settings['application_url'],
+        login_path=settings['login_path'],
+        callback_path=settings['callback_path'],
+        logout_path=settings['logout_path'],
         ), IOpenstaxAccountsAuthenticationPolicy)

--- a/openstax_accounts/authentication_policy.py
+++ b/openstax_accounts/authentication_policy.py
@@ -98,7 +98,7 @@ class OpenstaxAccountsAuthenticationPolicy(object):
         return groups
 
     def remember(self, request, principal, **kw):
-        pass
+        return []
 
     def forget(self, request):
         if self.unauthenticated_userid(request):
@@ -108,6 +108,7 @@ class OpenstaxAccountsAuthenticationPolicy(object):
             params = urlencode({'return_to': return_to})
             request.session.clear()
             raise HTTPFound(location='?'.join([logout_url, params]))
+        return []
 
 
 # BBB (11-Mar-2015) Deprecated, use 'includeme' by invoking

--- a/openstax_accounts/authentication_policy.py
+++ b/openstax_accounts/authentication_policy.py
@@ -34,7 +34,7 @@ def get_accounts_client(request):
     return client
 
 
-@implementer(IAuthenticationPolicy)
+@implementer(IOpenstaxAccountsAuthenticationPolicy)
 class OpenstaxAccountsAuthenticationPolicy(object):
 
     def __init__(self, application_url, login_path, callback_path, logout_path):

--- a/openstax_accounts/example.py
+++ b/openstax_accounts/example.py
@@ -156,6 +156,7 @@ def logout(request):
     forget(request)
     raise HTTPFound(location='/')
 
+
 def main(global_config, **settings):
     session_factory = UnencryptedCookieSessionFactoryConfig(
             str(uuid.uuid4()))
@@ -172,7 +173,7 @@ def main(global_config, **settings):
     config.add_route('logout', '/logout')
 
     config.scan(package='openstax_accounts.example')
-    config.include('openstax_accounts.main')
+    config.include('openstax_accounts')
 
     # authorization policy must be set if an authentication policy is set
     config.set_authentication_policy(

--- a/openstax_accounts/example.py
+++ b/openstax_accounts/example.py
@@ -37,6 +37,7 @@ def menu(request):
     <li>You are currently {login_status}.</li>
     <li><a href="{hello_world_path}">Hello World!</a></li>
     <li><a href="{profile_path}">Profile</a></li>
+    <li><a href="{membership_path}">Membership (JSON)</a></li>
     <li><a href="{user_search_path}">User Search</a></li>
     <li><a href="{user_search_json_path}">User Search (JSON)</a></li>
     <li><a href="{send_message_path}">Send Message</a></li>
@@ -47,6 +48,7 @@ def menu(request):
         login_logout_path=login_logout_path,
         login_logout_text=login_logout_text,
         profile_path=request.route_url('profile'),
+        membership_path=request.route_url('membership'),
         user_search_path=request.route_url('user-search', format=''),
         user_search_json_path=request.route_url('user-search', format='.json'),
         send_message_path=request.route_url('send-message'),
@@ -96,6 +98,15 @@ def profile(request):
            last_name=user.get('last_name', ''),
            full_name=user.get('full_name', ''))
     return Response(menu(request) + '<p>Profile</p>' + profile + profile_form)
+
+
+@view_config(route_name='membership', request_method='GET',
+             renderer='json')
+@authenticated_only
+def membership(request):
+    """Returns the `effective_principals` for the authenticated user."""
+    return request.effective_principals
+
 
 @view_config(route_name='profile', request_method='POST')
 @authenticated_only
@@ -149,6 +160,7 @@ def main(global_config, **settings):
     config.add_route('index', '/')
     config.add_route('hello-world', '/hello-world')
     config.add_route('profile', '/profile')
+    config.add_route('membership', '/membership.json')
     config.add_route('user-search', '/users/search{format:(.json)?}')
     config.add_route('send-message', '/message')
 

--- a/openstax_accounts/example.py
+++ b/openstax_accounts/example.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-
+# ###
+# Copyright (c) 2015, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
 import functools
 import json
 import uuid
@@ -14,14 +19,8 @@ from pyramid.url import route_url
 from pyramid.view import view_config
 
 from .interfaces import *
+from .views import authenticated_only
 
-def authenticated_only(function):
-    @functools.wraps(function)
-    def wrapper(request, *args, **kwargs):
-        if Authenticated not in request.effective_principals:
-            raise HTTPUnauthorized()
-        return function(request, *args, **kwargs)
-    return wrapper
 
 def menu(request):
     user = request.user
@@ -140,22 +139,6 @@ def send_message(request):
     util.send_message(username, subject, body)
     return Response(menu(request) + '<p>Message sent</p>')
 
-@view_config(route_name='callback')
-@authenticated_only
-def callback(request):
-    # callback must redirect
-    return HTTPFound(location='/')
-
-@view_config(route_name='login')
-@authenticated_only
-def login(request):
-    pass
-
-@view_config(route_name='logout')
-def logout(request):
-    forget(request)
-    raise HTTPFound(location='/')
-
 
 def main(global_config, **settings):
     session_factory = UnencryptedCookieSessionFactoryConfig(
@@ -168,12 +151,9 @@ def main(global_config, **settings):
     config.add_route('profile', '/profile')
     config.add_route('user-search', '/users/search{format:(.json)?}')
     config.add_route('send-message', '/message')
-    config.add_route('callback', '/callback')
-    config.add_route('login', '/login')
-    config.add_route('logout', '/logout')
 
-    config.scan(package='openstax_accounts.example')
     config.include('openstax_accounts')
+    config.scan(package='openstax_accounts.example')
 
     # authorization policy must be set if an authentication policy is set
     config.set_authentication_policy(

--- a/openstax_accounts/interfaces.py
+++ b/openstax_accounts/interfaces.py
@@ -1,11 +1,49 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2015, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
 from zope.interface import Interface
+from pyramid.interfaces import IAuthenticationPolicy
+
 
 class IOpenstaxAccounts(Interface):
-    pass
+    """Utility for interacting with the accounts application.
+    For accounts API documentation, visit ``/api/docs/v1`` on your
+    running instance of accounts.
+
+    """
+
+    def search(query, **kwargs):
+        """See ``/api/docs/v1/application_users/index``"""
+
+    def global_search(query):
+        """See ``/api/docs/v1/users/index``"""
+
+    def send_message(username, subject, text_body, html_body=None):
+        """Sends a single message to ``username`` with ``subject`` and
+        ``text_body``. If ``html_body`` is supplied that be sent as well.
+        See also ``/api/docs/v1/messages/create``
+        """
+
+    def get_profile():
+        """See ``/api/docs/v1/users/show``"""
+
+    def update_email(existing_emails, email):
+        """ Unknown? """
+
+    def update_profile(request, **post_data):
+        """See ``/api/docs/v1/users/update``"""
 
 
-class IOpenstaxAccountsAuthenticationPolicy(Interface):
-    pass
+class IOpenstaxAccountsAuthenticationPolicy(IAuthenticationPolicy):
+    """Custom interface for the authentication policy."""
+    # This is a separate interface so that we can specifically lookup
+    # the authentication policy used with accounts. We use more than
+    # one authentication policy in some of our packages, which is why
+    # this interface is need.
 
 
 class IMessageSender(Interface):

--- a/openstax_accounts/stub.py
+++ b/openstax_accounts/stub.py
@@ -49,7 +49,7 @@ def get_users_from_settings(setting):
     return users
 
 
-@implementer(IAuthenticationPolicy)
+@implementer(IOpenstaxAccountsAuthenticationPolicy)
 class StubAuthenticationPolicy(object):
     def __init__(self, users):
         self.users = users
@@ -209,6 +209,15 @@ class OpenstaxAccounts(object):
 
         write_util = get_current_registry().getUtility(IStubMessageWriter)
         write_util.write(json.dumps(msg_data))
+
+    def get_profile(self):
+        raise NotImplementedError
+
+    def update_email(self, existing_emails, email):
+        raise NotImplementedError
+
+    def update_profile(self, request, **post_data):
+        raise NotImplementedError
 
 
 def main(config):

--- a/openstax_accounts/stub.py
+++ b/openstax_accounts/stub.py
@@ -111,9 +111,11 @@ class StubAuthenticationPolicy(object):
             'profile': kw.get('profile'),
             })
         request.session.changed()
+        return []
 
     def forget(self, request):
         request.session.clear()
+        return []
 
 
 @view_config(route_name='stub-login-form', request_method=['GET', 'POST'])

--- a/openstax_accounts/tests.py
+++ b/openstax_accounts/tests.py
@@ -53,6 +53,24 @@ def read_config():
     return testing_ini, config, app_url
 
 
+class UtilsTests(unittest.TestCase):
+
+    def test_local_settings(self):
+        prefix = 'xyz'
+        settings = {
+            'xyz.foo': 'bar',
+            'xyz.bar': 'foo',
+            'oof': 'arb',
+            }
+        expected = {
+            'foo': 'bar',
+            'bar': 'foo',
+            }
+        # Test the utility...
+        from .utils import local_settings
+        self.assertEqual(expected, local_settings(settings, prefix='xyz'))
+
+
 class BrowserTestCase(object):
     def fill_in(self, label_text, value):
         for i in range(10):

--- a/openstax_accounts/tests.py
+++ b/openstax_accounts/tests.py
@@ -286,6 +286,14 @@ class StubFunctionalTests(BaseFunctionalTests):
               'first_name': 'Test', 'last_name': 'User', 'title': None,
               'full_name': 'Test User'},
              ])
+        # Check for group membership
+        self.driver.get(self.app_url)
+        self.follow_link('Membership (JSON)')
+        principals = json.loads(self.page_text())
+        self.assertEqual(len(principals), 5)
+        expected = ['g:grp_luna', 'g:grp_sol',
+                    'system.Authenticated', 'system.Everyone', 'u:babara']
+        self.assertEqual(sorted(principals), expected)
         # check messaging api
         self.driver.get(self.app_url)
         self.follow_link('Send Message')

--- a/openstax_accounts/tests.py
+++ b/openstax_accounts/tests.py
@@ -17,6 +17,7 @@ except ImportError:
 
 from pyramid.settings import asbool
 from selenium import webdriver
+from zope.interface.verify import verifyClass
 
 
 def screenshot_on_error(method):
@@ -71,7 +72,48 @@ class UtilsTests(unittest.TestCase):
         self.assertEqual(expected, local_settings(settings, prefix='xyz'))
 
 
+class InterfaceTests(unittest.TestCase):
+    """Verify the classes implement the interfaces."""
+
+    @property
+    def openstaxaccounts_iface(self):
+        from .interfaces import IOpenstaxAccounts as iface
+        return iface
+
+    @property
+    def authenticationpolicy_iface(self):
+        from pyramid.interfaces import IAuthenticationPolicy as iface
+        return iface
+
+    @property
+    def openstaxaccountsauthenticationpolicy_iface(self):
+        from .interfaces import IOpenstaxAccountsAuthenticationPolicy as iface
+        return iface
+
+    def test_stub(self):
+        from .stub import (
+            StubAuthenticationPolicy,
+            OpenstaxAccounts)
+        verifyClass(self.authenticationpolicy_iface,
+                    StubAuthenticationPolicy)
+        verifyClass(self.openstaxaccountsauthenticationpolicy_iface,
+                    StubAuthenticationPolicy)
+        verifyClass(self.openstaxaccounts_iface,
+                    OpenstaxAccounts)
+
+    def test_openstax_accounts(self):
+        from .openstax_accounts import OpenstaxAccounts
+        from .authentication_policy import OpenstaxAccountsAuthenticationPolicy
+        verifyClass(self.authenticationpolicy_iface,
+                    OpenstaxAccountsAuthenticationPolicy)
+        verifyClass(self.openstaxaccountsauthenticationpolicy_iface,
+                    OpenstaxAccountsAuthenticationPolicy)
+        verifyClass(self.openstaxaccounts_iface,
+                    OpenstaxAccounts)
+
+
 class BrowserTestCase(object):
+
     def fill_in(self, label_text, value):
         for i in range(10):
             # try this 10 times to minimize false negative results...

--- a/openstax_accounts/utils.py
+++ b/openstax_accounts/utils.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2015, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+
+
+__all__ = ('local_settings')
+
+
+def local_settings(settings, prefix='openstax_accounts'):
+    """Localizes the settings for the dotted prefix.
+    For example, if the prefix where 'xyz'::
+
+        {'xyz.foo': 'bar', 'other': 'something'}
+
+    Would become::
+
+        {'foo': 'bar'}
+
+    Note, that non-prefixed items are left out and the prefix is dropped.
+    """
+    prefix = "{}.".format(prefix)
+    new_settings = {k[len(prefix):]:v for k, v in settings.items()
+                    if k.startswith(prefix)}
+    return new_settings

--- a/openstax_accounts/views.py
+++ b/openstax_accounts/views.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2015, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+import functools
+
+from pyramid.security import forget
+from pyramid.view import view_config
+from pyramid import httpexceptions
+
+from .interfaces import *
+
+
+def authenticated_only(function):
+    """Decorates a view to ensure that it can only be accessed
+    by authenticated individuals.
+    """
+    @functools.wraps(function)
+    def wrapper(request, *args, **kwargs):
+        if not request.authenticated_userid:
+            raise httpexceptions.HTTPUnauthorized()
+        return function(request, *args, **kwargs)
+    return wrapper
+
+
+@view_config(route_name='login')
+def login(request):
+    """Redirects the user to the accounts login page."""
+    # Store where we should redirect to after login
+    referer = request.referer or '/'
+    redirect_to = request.params.get('redirect', referer)
+    if redirect_to == request.route_url('login'):
+        redirect_to = '/'
+    if request.unauthenticated_userid:
+        return httpexceptions.HTTPFound(location=redirect_to)
+    request.session.update({'redirect_to': redirect_to})
+    request.authenticated_userid  # triggers login
+
+
+@view_config(route_name='callback')
+@authenticated_only
+def callback(request):
+    """Called when the user returns from accounts with authenticated
+    credentials.
+    """
+    # callback must be protected so that effective_principals is called
+    # callback must redirect
+    redirect_to = '/'
+    if request.session.get('redirect_to'):
+        # redirect_to in session is from login
+        redirect_to = request.session.pop('redirect_to')
+    raise httpexceptions.HTTPFound(location=redirect_to)
+
+
+@view_config(route_name='logout')
+def logout(request):
+    """Logs out the user from the application."""
+    forget(request)
+    settings = request.registry.settings
+    redirects_to = settings.get(
+        'openstax_accounts.logout_redirects_to', '/')
+    raise httpexceptions.HTTPFound(location=redirects_to)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
         name='openstax-accounts',
-        version='0.15.0',
+        version='1.0.0',
         description='An example pyramid app that connects to openstax/accounts',
         long_description=open('README.rst').read(),
         author='Connexions team',

--- a/test_local.ini
+++ b/test_local.ini
@@ -4,6 +4,7 @@ openstax_accounts.stub = false
 [app:main]
 use = egg:openstax-accounts
 openstax_accounts.server_url = https://localhost:3000/
+openstax_accounts.disable_verify_ssl = true
 openstax_accounts.admin_login = admin
 openstax_accounts.admin_password = password
 openstax_accounts.application_id = 3a571d607b127ab9aa4a803b57584a286f0a789136c86da50a5706324f557e12

--- a/test_stub.ini
+++ b/test_stub.ini
@@ -11,6 +11,14 @@ openstax_accounts.stub.users =
     dale,password
     earl,password
     fabian,password
+# Group membership via configuration
+# format: openstax_accounts.groups.<group-name> = <multiline-user-list>
+openstax_accounts.groups.grp_sol =
+    aaron
+    babara
+openstax_accounts.groups.grp_luna =
+    babara
+    dale
 openstax_accounts.application_url = http://localhost:8000/
 openstax_accounts.login_path = /login
 openstax_accounts.callback_path = /callback


### PR DESCRIPTION
The interfaces have been populated and verified via tests. This makes for a better contract, especially since we have two implementations (stub and actual).

The login, logout and callback views have been added to this package. This was done so that the same views don't need to be recoded in publishing. (DRYing out things.) Also, the routes are being defined by the configured paths. Generally speaking, this allows us to ``config.include('openstax_accounts')`` and not worry about the details.

Tests have been refactored to skip local tests when the configuration is not supplied (see the travis config for an example). Basically, ``python setup.py test`` should work without expected errors.

This also adjusts the code to use the (pyramid) documented include conventions. It's always good to follow the recommended and documented way when possible, no? :)

Lastly, the concept of groups has been added to the authentication policies. This was done in an effort to create group for moderators and admins within cnx-publishing (and potentially cnx-authoring).