### PR TITLE
Use the plain user principal name, because it is used in authz logic.

### DIFF
--- a/openstax_accounts/authentication_policy.py
+++ b/openstax_accounts/authentication_policy.py
@@ -92,7 +92,8 @@ class OpenstaxAccountsAuthenticationPolicy(object):
         userid = self.authenticated_userid(request)
         if userid:
             groups.append(Authenticated)
-            groups.append('u:{}'.format(userid))
+            groups.append(userid)
+        # 'g:<name>' indicate group names.
         groups.extend(['g:{}'.format(name)
                        for name in self._membership(request, userid)])
         return groups

--- a/openstax_accounts/example.py
+++ b/openstax_accounts/example.py
@@ -26,7 +26,8 @@ def menu(request):
     user = request.user
     if user:
         login_status = 'logged in'
-        login_logout_path = request.route_url('logout')
+        login_logout_path = request.route_url('logout',
+                                              _query={'redirect': '/'})
         login_logout_text = 'Log out'
     else:
         login_status = 'not logged in'

--- a/openstax_accounts/stub.py
+++ b/openstax_accounts/stub.py
@@ -100,7 +100,7 @@ class StubAuthenticationPolicy(object):
         userid = self.authenticated_userid(request)
         if userid:
             principals.append(Authenticated)
-            principals.append('u:{}'.format(userid))
+            principals.append(userid)
         principals.extend(['g:{}'.format(name)
                            for name in self._membership(request, userid)])
         return principals

--- a/openstax_accounts/tests.py
+++ b/openstax_accounts/tests.py
@@ -292,8 +292,8 @@ class StubFunctionalTests(BaseFunctionalTests):
         self.follow_link('Membership (JSON)')
         principals = json.loads(self.page_text())
         self.assertEqual(len(principals), 5)
-        expected = ['g:grp_luna', 'g:grp_sol',
-                    'system.Authenticated', 'system.Everyone', 'u:babara']
+        expected = ['babara', 'g:grp_luna', 'g:grp_sol',
+                    'system.Authenticated', 'system.Everyone']
         self.assertEqual(sorted(principals), expected)
         # View another user's profile by username
         self.driver.get(self.app_url)

--- a/openstax_accounts/views.py
+++ b/openstax_accounts/views.py
@@ -58,8 +58,14 @@ def callback(request):
 @view_config(route_name='logout')
 def logout(request):
     """Logs out the user from the application."""
-    forget(request)
     settings = request.registry.settings
-    redirects_to = settings.get(
+    forget(request)
+    referer = request.referer
+    redirect_to = request.params.get('redirect', referer)
+    default_redirect_to = settings.get(
         'openstax_accounts.logout_redirects_to', '/')
-    raise httpexceptions.HTTPFound(location=redirects_to)
+
+    if redirect_to == request.route_url('logout') or redirect_to is None:
+        redirect_to = default_redirect_to
+
+    raise httpexceptions.HTTPFound(location=redirect_to)


### PR DESCRIPTION
Simple change from the 'u:' prefixed principal names to the unprefixed names. This is required to let things like ``request.has_permission('view', context)`` work again.